### PR TITLE
release of v0.1.6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,14 +16,17 @@
     "caplog",
     "cudnn",
     "dotenv",
+    "einops",
     "imread",
     "ipykernel",
+    "matplotlib",
     "ndarray",
     "numpy",
     "opencv",
     "pytest",
     "pythonpath",
-    "torchtyping"
+    "torchtyping",
+    "torchvision"
   ],
   "jupyter.notebookFileRoot": "${workspaceFolder}",
 }

--- a/LICENSE
+++ b/LICENSE
@@ -2,10 +2,6 @@ MIT License
 
 Copyright (c) 2025 kage1020
 
-This license applies to the core functionality of the Video Understanding Toolkit (VUT),
-EXCLUDING the model implementations in the vut/models directory, which may be subject to
-different licenses as specified in their respective directories.
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vut"
-version = "0.1.5"
+version = "0.1.6"
 description = "Toolkit for Video Understanding tasks"
 readme = "README.md"
 authors = [{ name = "kage1020", email = "contact@kage1020.com" }]
@@ -52,6 +52,7 @@ dev = [
     "colorspacious>=1.1.2",
     "ipykernel>=6.29.5",
     "mypy>=1.15.0",
+    "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "pytest-cov>=6.1.1",
     "pytest-mock>=3.14.0",

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -51,7 +51,7 @@ def video_boundary_dir():
     os.rmdir(temp_dir)
 
 
-def test_base__init_with_all_parameters(
+def test_base(
     class_mapping_file,
     action_mapping_file,
     video_action_mapping_file,
@@ -72,9 +72,9 @@ def test_base__init_with_all_parameters(
     assert base.index_to_text == {0: "cat", 1: "dog", 2: "bird"}
 
     expected_action_to_steps = {
-        0: ["walk", "run", "jump"],
-        1: ["sit", "down", "stay"],
-        2: ["eat", "drink"],
+        "0": ["walk", "run", "jump"],
+        "1": ["sit", "down", "stay"],
+        "2": ["eat", "drink"],
     }
     assert base.action_to_steps == expected_action_to_steps
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,137 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from vut.base import Base
+
+
+@pytest.fixture
+def class_mapping_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+        f.write("index,class\n0,cat\n1,dog\n2,bird\n")
+        file_path = f.name
+    yield file_path
+    os.remove(file_path)
+
+
+@pytest.fixture
+def action_mapping_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+        f.write("0,walk run jump\n1,sit down stay\n2,eat drink\n")
+        file_path = f.name
+    yield file_path
+    os.remove(file_path)
+
+
+@pytest.fixture
+def video_action_mapping_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+        f.write("video1,action1\nvideo2,action2\nvideo3,action1\n")
+        file_path = f.name
+    yield file_path
+    os.remove(file_path)
+
+
+@pytest.fixture
+def video_boundary_dir():
+    temp_dir = tempfile.mkdtemp()
+
+    with open(Path(temp_dir) / "video1.csv", "w") as f:
+        f.write("0,100\n101,200\n")
+
+    with open(Path(temp_dir) / "video2.csv", "w") as f:
+        f.write("0,150\n151,300\n")
+
+    yield temp_dir
+
+    for file in Path(temp_dir).iterdir():
+        file.unlink()
+    os.rmdir(temp_dir)
+
+
+def test_base__init_with_all_parameters(
+    class_mapping_file,
+    action_mapping_file,
+    video_action_mapping_file,
+    video_boundary_dir,
+):
+    backgrounds = ["bg1", "bg2"]
+
+    base = Base(
+        class_mapping_path=class_mapping_file,
+        class_mapping_has_header=True,
+        action_mapping_path=action_mapping_file,
+        video_action_mapping_path=video_action_mapping_file,
+        video_boundary_dir_path=video_boundary_dir,
+        backgrounds=backgrounds,
+    )
+
+    assert base.text_to_index == {"cat": 0, "dog": 1, "bird": 2}
+    assert base.index_to_text == {0: "cat", 1: "dog", 2: "bird"}
+
+    expected_action_to_steps = {
+        0: ["walk", "run", "jump"],
+        1: ["sit", "down", "stay"],
+        2: ["eat", "drink"],
+    }
+    assert base.action_to_steps == expected_action_to_steps
+
+    expected_video_to_action = {
+        "video1": "action1",
+        "video2": "action2",
+        "video3": "action1",
+    }
+    assert base.video_to_action == expected_video_to_action
+
+    expected_video_boundaries = {
+        "video1": [(0, 100), (101, 200)],
+        "video2": [(0, 150), (151, 300)],
+    }
+    assert base.video_boundaries == expected_video_boundaries
+
+    assert base.backgrounds == backgrounds
+
+
+def test_base__env_access():
+    base = Base()
+
+    os.environ["TEST_VAR"] = "test_value"
+    os.environ["TEST_BOOL"] = "true"
+    os.environ["TEST_INT"] = "42"
+    os.environ["TEST_FLOAT"] = "3.14"
+
+    try:
+        assert base.env("TEST_VAR") == "test_value"
+        assert base.env("NON_EXISTENT") == ""
+
+        assert base.env.bool("TEST_BOOL") is True
+        assert base.env.bool("NON_EXISTENT") is False
+
+        assert base.env.int("TEST_INT") == 42
+        assert base.env.int("NON_EXISTENT") == 0
+
+        assert base.env.float("TEST_FLOAT") == 3.14
+        assert base.env.float("NON_EXISTENT") == 0.0
+    finally:
+        for key in ["TEST_VAR", "TEST_BOOL", "TEST_INT", "TEST_FLOAT"]:
+            if key in os.environ:
+                del os.environ[key]
+
+
+def test_base__init_with_custom_separator():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+        f.write("0|cat\n1|dog\n2|bird\n")
+        file_path = f.name
+
+    try:
+        base = Base(class_mapping_path=file_path, class_mapping_separator="|")
+
+        expected_text_to_index = {"cat": 0, "dog": 1, "bird": 2}
+        expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
+
+        assert base.text_to_index == expected_text_to_index
+        assert base.index_to_text == expected_index_to_text
+    finally:
+        os.remove(file_path)

--- a/tests/test_cuda.py
+++ b/tests/test_cuda.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 import torch
-from pytest_mock import MockFixture
+from pytest_mock import MockerFixture
 
 from vut.cuda import get_device, load_model, save_model
 from vut.models import I3D
@@ -34,7 +34,7 @@ def test_get_device__invalid_id():
         get_device(-1)
 
 
-def test_load_model__valid_path(mocker: MockFixture):
+def test_load_model__valid_path(mocker: MockerFixture):
     model = I3D()
     logger = mocker.Mock()
     logger.info = mocker.Mock()
@@ -52,7 +52,7 @@ def test_load_model__valid_path(mocker: MockFixture):
         assert logger.warning.call_count == 0, "Logger should not log warning message"
 
 
-def test_load_model__no_logger(mocker: MockFixture):
+def test_load_model__no_logger(mocker: MockerFixture):
     model = I3D()
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -66,7 +66,7 @@ def test_load_model__no_logger(mocker: MockFixture):
         assert mock_logger.call_count == 1, "Logger should be called once"
 
 
-def test_load_model__with_device(mocker: MockFixture):
+def test_load_model__with_device(mocker: MockerFixture):
     model = I3D()
     device = get_device()
     model = model.to(device)
@@ -86,7 +86,7 @@ def test_load_model__with_device(mocker: MockFixture):
         assert logger.warning.call_count == 0, "Logger should not log warning message"
 
 
-def test_load_model__invalid_path(mocker: MockFixture):
+def test_load_model__invalid_path(mocker: MockerFixture):
     model = I3D()
     logger = mocker.Mock()
     logger.info = mocker.Mock()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -2,7 +2,7 @@ import logging
 import os
 import tempfile
 
-from pytest_mock import MockFixture
+from pytest_mock import MockerFixture
 
 from vut.logger import get_logger
 
@@ -34,7 +34,7 @@ def test_get_logger__file_only(caplog):
     temp_file.close()
 
 
-def test_get_logger__with_hydra(mocker: MockFixture, caplog):
+def test_get_logger__with_hydra(mocker: MockerFixture, caplog):
     config = mocker.Mock()
     with tempfile.TemporaryDirectory() as temp_dir:
         config.runtime.output_dir = temp_dir

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -159,20 +159,20 @@ def test_to_class_index__invalid_shape():
 
 def test_to_class_mapping():
     data = [(0, "cat"), (1, "dog"), (2, "bird")]
-    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
     expected_text_to_index = {"cat": 0, "dog": 1, "bird": 2}
-    index_to_text, text_to_index = to_class_mapping(data)
-    assert index_to_text == expected_index_to_text
+    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
+    text_to_index, index_to_text = to_class_mapping(data)
     assert text_to_index == expected_text_to_index
+    assert index_to_text == expected_index_to_text
 
 
 def test_to_class_mapping__empty():
     data = []
-    expected_index_to_text = {}
     expected_text_to_index = {}
-    index_to_text, text_to_index = to_class_mapping(data)
-    assert index_to_text == expected_index_to_text
+    expected_index_to_text = {}
+    text_to_index, index_to_text = to_class_mapping(data)
     assert text_to_index == expected_text_to_index
+    assert index_to_text == expected_index_to_text
 
 
 @pytest.fixture
@@ -196,21 +196,21 @@ def class_mapping_file_with_header():
 
 
 def test_load_class_mapping(class_mapping_file):
-    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
     expected_text_to_index = {"cat": 0, "dog": 1, "bird": 2}
-    index_to_text, text_to_index = load_class_mapping(class_mapping_file)
-    assert index_to_text == expected_index_to_text
+    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
+    text_to_index, index_to_text = load_class_mapping(class_mapping_file)
     assert text_to_index == expected_text_to_index
+    assert index_to_text == expected_index_to_text
 
 
 def test_load_class_mapping__with_header(class_mapping_file_with_header):
-    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
     expected_text_to_index = {"cat": 0, "dog": 1, "bird": 2}
-    index_to_text, text_to_index = load_class_mapping(
+    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
+    text_to_index, index_to_text = load_class_mapping(
         class_mapping_file_with_header, has_header=True
     )
-    assert index_to_text == expected_index_to_text
     assert text_to_index == expected_text_to_index
+    assert index_to_text == expected_index_to_text
 
 
 def test_load_class_mapping__file_not_found():
@@ -230,8 +230,8 @@ def action_mapping_file():
 
 def test_load_action_mapping(action_mapping_file):
     expected_mapping = {
-        0: ["action_a", "step_a1", "step_a2"],
-        1: ["action_b", "step_b1"],
+        "0": ["action_a", "step_a1", "step_a2"],
+        "1": ["action_b", "step_b1"],
     }
     mapping = load_action_mapping(action_mapping_file, step_separator=" ")
     assert mapping == expected_mapping

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,8 +1,20 @@
+import tempfile
+from pathlib import Path
+
 import numpy as np
 import pytest
 import torch
 
-from vut.mapping import to_class_index, to_class_name
+from vut.mapping import (
+    load_action_mapping,
+    load_class_mapping,
+    load_video_action_mapping,
+    load_video_boundaries,
+    load_video_boundaries_from_file,
+    to_class_index,
+    to_class_mapping,
+    to_class_name,
+)
 
 
 def test_to_class_name():
@@ -143,3 +155,164 @@ def test_to_class_index__invalid_shape():
     names = [["cat", "dog"], ["bird"]]
     with pytest.raises(AssertionError):
         to_class_index(names, mapping)
+
+
+def test_to_class_mapping():
+    data = [(0, "cat"), (1, "dog"), (2, "bird")]
+    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
+    expected_text_to_index = {"cat": 0, "dog": 1, "bird": 2}
+    index_to_text, text_to_index = to_class_mapping(data)
+    assert index_to_text == expected_index_to_text
+    assert text_to_index == expected_text_to_index
+
+
+def test_to_class_mapping__empty():
+    data = []
+    expected_index_to_text = {}
+    expected_text_to_index = {}
+    index_to_text, text_to_index = to_class_mapping(data)
+    assert index_to_text == expected_index_to_text
+    assert text_to_index == expected_text_to_index
+
+
+@pytest.fixture
+def class_mapping_file():
+    content = "0,cat\n1,dog\n2,bird"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write(content)
+        filepath = f.name
+    yield filepath
+    Path(filepath).unlink()
+
+
+@pytest.fixture
+def class_mapping_file_with_header():
+    content = "index,name\n0,cat\n1,dog\n2,bird"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write(content)
+        filepath = f.name
+    yield filepath
+    Path(filepath).unlink()
+
+
+def test_load_class_mapping(class_mapping_file):
+    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
+    expected_text_to_index = {"cat": 0, "dog": 1, "bird": 2}
+    index_to_text, text_to_index = load_class_mapping(class_mapping_file)
+    assert index_to_text == expected_index_to_text
+    assert text_to_index == expected_text_to_index
+
+
+def test_load_class_mapping__with_header(class_mapping_file_with_header):
+    expected_index_to_text = {0: "cat", 1: "dog", 2: "bird"}
+    expected_text_to_index = {"cat": 0, "dog": 1, "bird": 2}
+    index_to_text, text_to_index = load_class_mapping(
+        class_mapping_file_with_header, has_header=True
+    )
+    assert index_to_text == expected_index_to_text
+    assert text_to_index == expected_text_to_index
+
+
+def test_load_class_mapping__file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_class_mapping("non_existent_file.csv")
+
+
+@pytest.fixture
+def action_mapping_file():
+    content = "0,action_a step_a1 step_a2\n1,action_b step_b1"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write(content)
+        filepath = f.name
+    yield filepath
+    Path(filepath).unlink()
+
+
+def test_load_action_mapping(action_mapping_file):
+    expected_mapping = {
+        0: ["action_a", "step_a1", "step_a2"],
+        1: ["action_b", "step_b1"],
+    }
+    mapping = load_action_mapping(action_mapping_file, step_separator=" ")
+    assert mapping == expected_mapping
+
+
+def test_load_action_mapping__file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_action_mapping("non_existent_file.csv")
+
+
+@pytest.fixture
+def video_action_mapping_file():
+    content = "video1,action_a\nvideo2,action_b"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write(content)
+        filepath = f.name
+    yield filepath
+    Path(filepath).unlink()
+
+
+def test_load_video_action_mapping(video_action_mapping_file):
+    expected_mapping = {
+        "video1": "action_a",
+        "video2": "action_b",
+    }
+    mapping = load_video_action_mapping(video_action_mapping_file)
+    assert mapping == expected_mapping
+
+
+def test_load_video_action_mapping__file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_video_action_mapping("non_existent_file.csv")
+
+
+@pytest.fixture
+def video_boundaries_file():
+    content = "0,100\n101,200"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write(content)
+        filepath = f.name
+    yield filepath
+    Path(filepath).unlink()
+
+
+def test_load_video_boundaries_from_file(video_boundaries_file):
+    expected_boundaries = [(0, 100), (101, 200)]
+    boundaries = load_video_boundaries_from_file(video_boundaries_file)
+    assert boundaries == expected_boundaries
+
+
+def test_load_video_boundaries_from_file__file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_video_boundaries_from_file("non_existent_file.csv")
+
+
+@pytest.fixture
+def video_boundaries_dir(tmp_path):
+    dir_path = tmp_path / "boundaries"
+    dir_path.mkdir()
+    (dir_path / "video1.csv").write_text("0,10\n11,20")
+    (dir_path / "video2.txt").write_text("100,110\n111,120")
+    return dir_path
+
+
+def test_load_video_boundaries(video_boundaries_dir):
+    expected_mapping = {
+        "video1": [(0, 10), (11, 20)],
+        "video2": [(100, 110), (111, 120)],
+    }
+    mapping = load_video_boundaries(video_boundaries_dir)
+    assert mapping == expected_mapping
+
+
+def test_load_video_boundaries__dir_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_video_boundaries("non_existent_dir")
+
+
+def test_load_video_boundaries__not_a_dir():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        filepath = f.name
+    with pytest.raises(NotADirectoryError):
+        load_video_boundaries(filepath)
+    Path(filepath).unlink()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pytest
 import torch
-from pytest_mock import MockFixture
+from pytest_mock import MockerFixture
 
 from vut.util import Env, init_seed, to_list, to_np, to_tensor, unique
 
@@ -148,25 +148,25 @@ def test_to_tensor__unsupported_type():
         to_tensor("unsupported type")
 
 
-def test_env(mocker: MockFixture):
+def test_env(mocker: MockerFixture):
     mocker.patch.dict(os.environ, {"VUT_ENV": "test_env"})
     env = Env()
     assert env("VUT_ENV") == "test_env", "Should return the value of VUT_ENV"
 
 
-def test_env_bool(mocker: MockFixture):
+def test_env_bool(mocker: MockerFixture):
     mocker.patch.dict(os.environ, {"VUT_ENV": "True"})
     env = Env()
     assert env.bool("VUT_ENV") is True, "Should return True for 'True' string"
 
 
-def test_env_int(mocker: MockFixture):
+def test_env_int(mocker: MockerFixture):
     mocker.patch.dict(os.environ, {"VUT_ENV": "42"})
     env = Env()
     assert env.int("VUT_ENV") == 42, "Should return the integer value of VUT_ENV"
 
 
-def test_env_float(mocker: MockFixture):
+def test_env_float(mocker: MockerFixture):
     mocker.patch.dict(os.environ, {"VUT_ENV": "3.14"})
     env = Env()
     assert env.float("VUT_ENV") == 3.14, "Should return the float value of VUT_ENV"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,11 @@
+import os
+
 import numpy as np
 import pytest
 import torch
+from pytest_mock import MockFixture
 
-from vut.util import init_seed, to_list, to_np, to_tensor, unique
+from vut.util import Env, init_seed, to_list, to_np, to_tensor, unique
 
 
 def test_init_seed__same_values():
@@ -143,3 +146,27 @@ def test_to_tensor__tensor():
 def test_to_tensor__unsupported_type():
     with pytest.raises(TypeError):
         to_tensor("unsupported type")
+
+
+def test_env(mocker: MockFixture):
+    mocker.patch.dict(os.environ, {"VUT_ENV": "test_env"})
+    env = Env()
+    assert env("VUT_ENV") == "test_env", "Should return the value of VUT_ENV"
+
+
+def test_env_bool(mocker: MockFixture):
+    mocker.patch.dict(os.environ, {"VUT_ENV": "True"})
+    env = Env()
+    assert env.bool("VUT_ENV") is True, "Should return True for 'True' string"
+
+
+def test_env_int(mocker: MockFixture):
+    mocker.patch.dict(os.environ, {"VUT_ENV": "42"})
+    env = Env()
+    assert env.int("VUT_ENV") == 42, "Should return the integer value of VUT_ENV"
+
+
+def test_env_float(mocker: MockFixture):
+    mocker.patch.dict(os.environ, {"VUT_ENV": "3.14"})
+    env = Env()
+    assert env.float("VUT_ENV") == 3.14, "Should return the float value of VUT_ENV"

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -24,6 +24,31 @@ def img():
     return np.ceil(np.random.rand(100, 100, 3) * 255).astype(np.uint8)
 
 
+@pytest.fixture
+def mock_ffmpeg(mocker: MockerFixture):
+    """Mock ffmpeg to avoid dependency on ffmpeg installation"""
+    mock_stdin = mocker.Mock()
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.close = mocker.Mock()
+
+    mock_process = mocker.Mock()
+    mock_process.stdin = mock_stdin
+    mock_process.wait = mocker.Mock()
+
+    mock_stream = mocker.Mock()
+    mock_stream.output = mocker.Mock(return_value=mock_stream)
+    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
+    mock_stream.run_async = mocker.Mock(return_value=mock_process)
+
+    mocker.patch("ffmpeg.input", return_value=mock_stream)
+
+    return {
+        "stdin": mock_stdin,
+        "process": mock_process,
+        "stream": mock_stream,
+    }
+
+
 def test_plot_palette__save_as_file(mocker: MockerFixture):
     mocker.patch("matplotlib.pyplot.get_cmap", return_value="viridis")
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
@@ -404,22 +429,7 @@ def test_plot_roc_curve__invalid_ground_truth_labels():
         plot_roc_curve(ground_truth, prediction)
 
 
-def test_make_video__with_image_paths(mocker: MockerFixture):
-    mock_stdin = mocker.Mock()
-    mock_stdin.write = mocker.Mock()
-    mock_stdin.close = mocker.Mock()
-
-    mock_process = mocker.Mock()
-    mock_process.stdin = mock_stdin
-    mock_process.wait = mocker.Mock()
-
-    mock_stream = mocker.Mock()
-    mock_stream.output = mocker.Mock(return_value=mock_stream)
-    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
-    mock_stream.run_async = mocker.Mock(return_value=mock_process)
-
-    mocker.patch("ffmpeg.input", return_value=mock_stream)
-
+def test_make_video__with_image_paths(mock_ffmpeg):
     image_paths = []
     temp_files = []
 
@@ -439,10 +449,10 @@ def test_make_video__with_image_paths(mocker: MockerFixture):
     try:
         make_video(image_paths=image_paths, path=video_path)
 
-        assert mock_stream.output.called
-        assert mock_stream.overwrite_output.called
-        assert mock_stream.run_async.called
-        assert mock_stdin.write.called
+        assert mock_ffmpeg["stream"].output.called
+        assert mock_ffmpeg["stream"].overwrite_output.called
+        assert mock_ffmpeg["stream"].run_async.called
+        assert mock_ffmpeg["stdin"].write.called
 
     finally:
         for temp_file in temp_files:
@@ -452,37 +462,7 @@ def test_make_video__with_image_paths(mocker: MockerFixture):
             os.remove(video_path)
 
 
-def test_make_video__with_labels_and_data(mocker: MockerFixture):
-    mock_stdin = mocker.Mock()
-    mock_stdin.write = mocker.Mock()
-    mock_stdin.close = mocker.Mock()
-
-    mock_process = mocker.Mock()
-    mock_process.stdin = mock_stdin
-    mock_process.wait = mocker.Mock()
-
-    mock_stream = mocker.Mock()
-    mock_stream.output = mocker.Mock(return_value=mock_stream)
-    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
-    mock_stream.run_async = mocker.Mock(return_value=mock_process)
-
-    mocker.patch("ffmpeg.input", return_value=mock_stream)
-
-    mock_stdin = mocker.Mock()
-    mock_stdin.write = mocker.Mock()
-    mock_stdin.close = mocker.Mock()
-
-    mock_process = mocker.Mock()
-    mock_process.stdin = mock_stdin
-    mock_process.wait = mocker.Mock()
-
-    mock_stream = mocker.Mock()
-    mock_stream.output = mocker.Mock(return_value=mock_stream)
-    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
-    mock_stream.run_async = mocker.Mock(return_value=mock_process)
-
-    mocker.patch("ffmpeg.input", return_value=mock_stream)
-
+def test_make_video__with_labels_and_data(mock_ffmpeg):
     image_paths = []
     temp_files = []
 
@@ -518,10 +498,10 @@ def test_make_video__with_labels_and_data(mocker: MockerFixture):
             legend_ncol=3,
         )
 
-        assert mock_stream.output.called
-        assert mock_stream.overwrite_output.called
-        assert mock_stream.run_async.called
-        assert mock_stdin.write.called
+        assert mock_ffmpeg["stream"].output.called
+        assert mock_ffmpeg["stream"].overwrite_output.called
+        assert mock_ffmpeg["stream"].run_async.called
+        assert mock_ffmpeg["stdin"].write.called
 
     finally:
         for temp_file in temp_files:
@@ -531,22 +511,7 @@ def test_make_video__with_labels_and_data(mocker: MockerFixture):
             os.remove(video_path)
 
 
-def test_make_video__no_segmentation_data(mocker: MockerFixture):
-    mock_stdin = mocker.Mock()
-    mock_stdin.write = mocker.Mock()
-    mock_stdin.close = mocker.Mock()
-
-    mock_process = mocker.Mock()
-    mock_process.stdin = mock_stdin
-    mock_process.wait = mocker.Mock()
-
-    mock_stream = mocker.Mock()
-    mock_stream.output = mocker.Mock(return_value=mock_stream)
-    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
-    mock_stream.run_async = mocker.Mock(return_value=mock_process)
-
-    mocker.patch("ffmpeg.input", return_value=mock_stream)
-
+def test_make_video__no_segmentation_data(mock_ffmpeg):
     image_paths = []
     temp_files = []
 
@@ -572,10 +537,10 @@ def test_make_video__no_segmentation_data(mocker: MockerFixture):
             fps=1,
         )
 
-        assert mock_stream.output.called
-        assert mock_stream.overwrite_output.called
-        assert mock_stream.run_async.called
-        assert mock_stdin.write.called
+        assert mock_ffmpeg["stream"].output.called
+        assert mock_ffmpeg["stream"].overwrite_output.called
+        assert mock_ffmpeg["stream"].run_async.called
+        assert mock_ffmpeg["stdin"].write.called
 
     finally:
         for temp_file in temp_files:

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -58,7 +58,7 @@ def test_plot_image__show_in_jupyter(img, mocker: MockerFixture):
 
 def test_plot_image__return_canvas(img):
     canvas = plot_image(img, return_canvas=True)
-    assert canvas.shape == (480, 640, 3)
+    assert canvas.shape == (600, 800, 3)
 
 
 def test_plot_images__save_as_file(img):
@@ -106,7 +106,7 @@ def test_plot_feature__show_in_jupyter(mocker: MockerFixture):
 def test_plot_feature__return_canvas():
     feature = np.random.rand(10, 10)
     canvas = plot_feature(feature, return_canvas=True)
-    assert canvas.shape == (480, 640, 3)
+    assert canvas.shape == (600, 800, 3)
 
 
 def test_plot_features__save_as_file():
@@ -404,7 +404,22 @@ def test_plot_roc_curve__invalid_ground_truth_labels():
         plot_roc_curve(ground_truth, prediction)
 
 
-def test_make_video__with_image_paths():
+def test_make_video__with_image_paths(mocker: MockerFixture):
+    mock_stdin = mocker.Mock()
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.close = mocker.Mock()
+
+    mock_process = mocker.Mock()
+    mock_process.stdin = mock_stdin
+    mock_process.wait = mocker.Mock()
+
+    mock_stream = mocker.Mock()
+    mock_stream.output = mocker.Mock(return_value=mock_stream)
+    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
+    mock_stream.run_async = mocker.Mock(return_value=mock_process)
+
+    mocker.patch("ffmpeg.input", return_value=mock_stream)
+
     image_paths = []
     temp_files = []
 
@@ -424,8 +439,10 @@ def test_make_video__with_image_paths():
     try:
         make_video(image_paths=image_paths, path=video_path)
 
-        assert os.path.exists(video_path)
-        assert os.path.getsize(video_path) > 0
+        assert mock_stream.output.called
+        assert mock_stream.overwrite_output.called
+        assert mock_stream.run_async.called
+        assert mock_stdin.write.called
 
     finally:
         for temp_file in temp_files:
@@ -435,7 +452,37 @@ def test_make_video__with_image_paths():
             os.remove(video_path)
 
 
-def test_make_video__with_labels_and_data():
+def test_make_video__with_labels_and_data(mocker: MockerFixture):
+    mock_stdin = mocker.Mock()
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.close = mocker.Mock()
+
+    mock_process = mocker.Mock()
+    mock_process.stdin = mock_stdin
+    mock_process.wait = mocker.Mock()
+
+    mock_stream = mocker.Mock()
+    mock_stream.output = mocker.Mock(return_value=mock_stream)
+    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
+    mock_stream.run_async = mocker.Mock(return_value=mock_process)
+
+    mocker.patch("ffmpeg.input", return_value=mock_stream)
+
+    mock_stdin = mocker.Mock()
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.close = mocker.Mock()
+
+    mock_process = mocker.Mock()
+    mock_process.stdin = mock_stdin
+    mock_process.wait = mocker.Mock()
+
+    mock_stream = mocker.Mock()
+    mock_stream.output = mocker.Mock(return_value=mock_stream)
+    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
+    mock_stream.run_async = mocker.Mock(return_value=mock_process)
+
+    mocker.patch("ffmpeg.input", return_value=mock_stream)
+
     image_paths = []
     temp_files = []
 
@@ -471,8 +518,10 @@ def test_make_video__with_labels_and_data():
             legend_ncol=3,
         )
 
-        assert os.path.exists(video_path)
-        assert os.path.getsize(video_path) > 0
+        assert mock_stream.output.called
+        assert mock_stream.overwrite_output.called
+        assert mock_stream.run_async.called
+        assert mock_stdin.write.called
 
     finally:
         for temp_file in temp_files:
@@ -482,7 +531,22 @@ def test_make_video__with_labels_and_data():
             os.remove(video_path)
 
 
-def test_make_video__no_segmentation_data():
+def test_make_video__no_segmentation_data(mocker: MockerFixture):
+    mock_stdin = mocker.Mock()
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.close = mocker.Mock()
+
+    mock_process = mocker.Mock()
+    mock_process.stdin = mock_stdin
+    mock_process.wait = mocker.Mock()
+
+    mock_stream = mocker.Mock()
+    mock_stream.output = mocker.Mock(return_value=mock_stream)
+    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
+    mock_stream.run_async = mocker.Mock(return_value=mock_process)
+
+    mocker.patch("ffmpeg.input", return_value=mock_stream)
+
     image_paths = []
     temp_files = []
 
@@ -500,7 +564,6 @@ def test_make_video__no_segmentation_data():
         video_path = video_file.name
 
     try:
-        # Test video creation without segmentation data
         make_video(
             image_paths=image_paths,
             path=video_path,
@@ -509,8 +572,10 @@ def test_make_video__no_segmentation_data():
             fps=1,
         )
 
-        assert os.path.exists(video_path)
-        assert os.path.getsize(video_path) > 0
+        assert mock_stream.output.called
+        assert mock_stream.overwrite_output.called
+        assert mock_stream.run_async.called
+        assert mock_stdin.write.called
 
     finally:
         for temp_file in temp_files:

--- a/tests/video/test_writer.py
+++ b/tests/video/test_writer.py
@@ -3,11 +3,27 @@ import tempfile
 
 import numpy as np
 from PIL import Image
+from pytest_mock import MockerFixture
 
 from vut.video.writer import VideoWriter
 
 
-def test_video_writer__init():
+def test_video_writer__init(mocker: MockerFixture):
+    mock_stdin = mocker.Mock()
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.close = mocker.Mock()
+
+    mock_process = mocker.Mock()
+    mock_process.stdin = mock_stdin
+    mock_process.wait = mocker.Mock()
+
+    mock_stream = mocker.Mock()
+    mock_stream.output = mocker.Mock(return_value=mock_stream)
+    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
+    mock_stream.run_async = mocker.Mock(return_value=mock_process)
+
+    mocker.patch("ffmpeg.input", return_value=mock_stream)
+
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as temp_file:
         filename = temp_file.name
 
@@ -28,7 +44,22 @@ def test_video_writer__init():
         os.remove(filename)
 
 
-def test_video_writer__resize():
+def test_video_writer__resize(mocker: MockerFixture):
+    mock_stdin = mocker.Mock()
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.close = mocker.Mock()
+
+    mock_process = mocker.Mock()
+    mock_process.stdin = mock_stdin
+    mock_process.wait = mocker.Mock()
+
+    mock_stream = mocker.Mock()
+    mock_stream.output = mocker.Mock(return_value=mock_stream)
+    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
+    mock_stream.run_async = mocker.Mock(return_value=mock_process)
+
+    mocker.patch("ffmpeg.input", return_value=mock_stream)
+
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as temp_file:
         filename = temp_file.name
 
@@ -43,7 +74,22 @@ def test_video_writer__resize():
         os.remove(filename)
 
 
-def test_video_writer__update():
+def test_video_writer__update(mocker: MockerFixture):
+    mock_stdin = mocker.Mock()
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.close = mocker.Mock()
+
+    mock_process = mocker.Mock()
+    mock_process.stdin = mock_stdin
+    mock_process.wait = mocker.Mock()
+
+    mock_stream = mocker.Mock()
+    mock_stream.output = mocker.Mock(return_value=mock_stream)
+    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
+    mock_stream.run_async = mocker.Mock(return_value=mock_process)
+
+    mocker.patch("ffmpeg.input", return_value=mock_stream)
+
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as temp_file:
         filename = temp_file.name
 
@@ -52,6 +98,11 @@ def test_video_writer__update():
             image = Image.new("RGB", (640, 480), color="red")
             writer.update(image)
 
-            assert os.path.exists(filename)
+            assert mock_stream.output.called
+            assert mock_stream.overwrite_output.called
+            assert mock_stream.run_async.called
+            assert mock_stdin.write.called
+
+        assert os.path.exists(filename)
     finally:
         os.remove(filename)

--- a/tests/video/test_writer.py
+++ b/tests/video/test_writer.py
@@ -2,13 +2,16 @@ import os
 import tempfile
 
 import numpy as np
+import pytest
 from PIL import Image
 from pytest_mock import MockerFixture
 
 from vut.video.writer import VideoWriter
 
 
-def test_video_writer__init(mocker: MockerFixture):
+@pytest.fixture
+def mock_ffmpeg(mocker: MockerFixture):
+    """Mock ffmpeg to avoid dependency on ffmpeg installation"""
     mock_stdin = mocker.Mock()
     mock_stdin.write = mocker.Mock()
     mock_stdin.close = mocker.Mock()
@@ -24,6 +27,14 @@ def test_video_writer__init(mocker: MockerFixture):
 
     mocker.patch("ffmpeg.input", return_value=mock_stream)
 
+    return {
+        "stdin": mock_stdin,
+        "process": mock_process,
+        "stream": mock_stream,
+    }
+
+
+def test_video_writer__init():
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as temp_file:
         filename = temp_file.name
 
@@ -44,22 +55,7 @@ def test_video_writer__init(mocker: MockerFixture):
         os.remove(filename)
 
 
-def test_video_writer__resize(mocker: MockerFixture):
-    mock_stdin = mocker.Mock()
-    mock_stdin.write = mocker.Mock()
-    mock_stdin.close = mocker.Mock()
-
-    mock_process = mocker.Mock()
-    mock_process.stdin = mock_stdin
-    mock_process.wait = mocker.Mock()
-
-    mock_stream = mocker.Mock()
-    mock_stream.output = mocker.Mock(return_value=mock_stream)
-    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
-    mock_stream.run_async = mocker.Mock(return_value=mock_process)
-
-    mocker.patch("ffmpeg.input", return_value=mock_stream)
-
+def test_video_writer__resize():
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as temp_file:
         filename = temp_file.name
 
@@ -74,22 +70,7 @@ def test_video_writer__resize(mocker: MockerFixture):
         os.remove(filename)
 
 
-def test_video_writer__update(mocker: MockerFixture):
-    mock_stdin = mocker.Mock()
-    mock_stdin.write = mocker.Mock()
-    mock_stdin.close = mocker.Mock()
-
-    mock_process = mocker.Mock()
-    mock_process.stdin = mock_stdin
-    mock_process.wait = mocker.Mock()
-
-    mock_stream = mocker.Mock()
-    mock_stream.output = mocker.Mock(return_value=mock_stream)
-    mock_stream.overwrite_output = mocker.Mock(return_value=mock_stream)
-    mock_stream.run_async = mocker.Mock(return_value=mock_process)
-
-    mocker.patch("ffmpeg.input", return_value=mock_stream)
-
+def test_video_writer__update(mock_ffmpeg):
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as temp_file:
         filename = temp_file.name
 
@@ -98,10 +79,10 @@ def test_video_writer__update(mocker: MockerFixture):
             image = Image.new("RGB", (640, 480), color="red")
             writer.update(image)
 
-            assert mock_stream.output.called
-            assert mock_stream.overwrite_output.called
-            assert mock_stream.run_async.called
-            assert mock_stdin.write.called
+            assert mock_ffmpeg["stream"].output.called
+            assert mock_ffmpeg["stream"].overwrite_output.called
+            assert mock_ffmpeg["stream"].run_async.called
+            assert mock_ffmpeg["stdin"].write.called
 
         assert os.path.exists(filename)
     finally:

--- a/uv.lock
+++ b/uv.lock
@@ -117,6 +117,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -312,6 +321,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -429,6 +447,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254, upload-time = "2025-05-23T20:37:53.3Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/cd/18f8da995b658420625f7ef13f037be53ae04ec5ad33f9b718240dcfd48c/identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2", size = 99145, upload-time = "2025-05-23T20:37:51.495Z" },
 ]
 
 [[package]]
@@ -851,6 +878,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1203,6 +1239,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/c0/90fcaac5c95aa225b3899698289c0424d429ef72248b593f15294f95a35e/polars-1.29.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:7a0ac6a11088279af4d715f4b58068835f551fa5368504a53401743006115e78", size = 32073830, upload-time = "2025-04-30T20:56:26.742Z" },
     { url = "https://files.pythonhosted.org/packages/17/ed/e5e570e22a03549a3c5397035a006b2c6343856a9fd15cccb5db39bdfa0a/polars-1.29.0-cp39-abi3-win_amd64.whl", hash = "sha256:f5aac4656e58b1e12f9481950981ef68b5b0e53dd4903bd72472efd2d09a74c8", size = 34971841, upload-time = "2025-04-30T20:56:29.953Z" },
     { url = "https://files.pythonhosted.org/packages/45/fd/9039f609d76b3ebb13777f289502a00b52709aea5c35aed01d1090ac142f/polars-1.29.0-cp39-abi3-win_arm64.whl", hash = "sha256:0c105b07b980b77fe88c3200b015bf4695e53185385f0f244c13e2d1027c7bbf", size = 31298689, upload-time = "2025-04-30T20:56:33.449Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
 ]
 
 [[package]]
@@ -1938,8 +1990,22 @@ wheels = [
 ]
 
 [[package]]
+name = "virtualenv"
+version = "20.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316, upload-time = "2025-05-08T17:58:23.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982, upload-time = "2025-05-08T17:58:21.15Z" },
+]
+
+[[package]]
 name = "vut"
-version = "0.1.5"
+version = "0.1.6"
 source = { virtual = "." }
 dependencies = [
     { name = "einops" },
@@ -1965,6 +2031,7 @@ dev = [
     { name = "colorspacious" },
     { name = "ipykernel" },
     { name = "mypy" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
@@ -1997,6 +2064,7 @@ dev = [
     { name = "colorspacious", specifier = ">=1.1.2" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "mypy", specifier = ">=1.15.0" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = ">=3.14.0" },

--- a/vut/__init__.py
+++ b/vut/__init__.py
@@ -1,5 +1,6 @@
 from matplotlib.colors import to_hex, to_rgb, to_rgba
 
+from .base import Base
 from .cuda import get_device, load_model, save_model
 from .io import (
     get_dirs,
@@ -16,11 +17,20 @@ from .io import (
     save_np,
     save_tensor,
 )
-from .mapping import to_class_index, to_class_name
+from .mapping import (
+    load_action_mapping,
+    load_class_mapping,
+    load_video_action_mapping,
+    load_video_boundaries,
+    load_video_boundaries_from_file,
+    to_class_index,
+    to_class_mapping,
+    to_class_name,
+)
 from .palette import RGB, ColorMapName, create_palette, template
 from .reduction import compute_tsne
 from .time import format_time, get_elapsed_time, get_time
-from .util import init_seed, to_list, to_np, to_tensor, unique
+from .util import Env, init_seed, to_list, to_np, to_tensor, unique
 from .visualize import (
     make_video,
     plot_action_segmentation,
@@ -35,11 +45,18 @@ from .visualize import (
 )
 
 __all__ = [
+    "Base",
     "ColorMapName",
     "compute_tsne",
     "create_palette",
+    "Env",
     "format_time",
     "init_seed",
+    "load_action_mapping",
+    "load_class_mapping",
+    "load_video_action_mapping",
+    "load_video_boundaries",
+    "load_video_boundaries_from_file",
     "load_file",
     "load_image",
     "load_images",
@@ -71,6 +88,7 @@ __all__ = [
     "save_tensor",
     "template",
     "to_class_index",
+    "to_class_mapping",
     "to_class_name",
     "to_hex",
     "to_list",

--- a/vut/base.py
+++ b/vut/base.py
@@ -1,0 +1,67 @@
+from vut.mapping import (
+    load_action_mapping,
+    load_class_mapping,
+    load_video_action_mapping,
+    load_video_boundaries,
+)
+from vut.util import Env
+
+
+class Base:
+    env = Env()
+    text_to_index: dict[str, int] = {}
+    index_to_text: dict[int, str] = {}
+    action_to_steps: dict[str, list[str]] = {}
+    video_to_action: dict[str, str] = {}
+    video_boundaries: dict[str, list[tuple[int, int]]] = {}
+    backgrounds: list[str] = []
+
+    def __init__(
+        self,
+        class_mapping_path: str | None = None,
+        class_mapping_has_header: bool = None,
+        class_mapping_separator: str | None = ",",
+        action_mapping_path: str | None = None,
+        action_mapping_has_header: bool = False,
+        action_mapping_action_separator: str = ",",
+        action_mapping_step_separator: str = " ",
+        video_action_mapping_path: str | None = None,
+        video_action_mapping_has_header: bool = False,
+        video_action_mapping_separator: str = ",",
+        video_boundary_dir_path: str | None = None,
+        video_boundary_has_header: bool = False,
+        video_boundary_separator: str = ",",
+        backgrounds: list[str] | None = None,
+    ):
+        if class_mapping_path is not None:
+            text_to_index, index_to_text = load_class_mapping(
+                class_mapping_path,
+                has_header=class_mapping_has_header,
+                separator=class_mapping_separator,
+            )
+            self.text_to_index = text_to_index
+            self.index_to_text = index_to_text
+        if action_mapping_path is not None:
+            action_to_steps = load_action_mapping(
+                action_mapping_path,
+                has_header=action_mapping_has_header,
+                action_separator=action_mapping_action_separator,
+                step_separator=action_mapping_step_separator,
+            )
+            self.action_to_steps = action_to_steps
+        if video_action_mapping_path is not None:
+            video_to_action = load_video_action_mapping(
+                video_action_mapping_path,
+                has_header=video_action_mapping_has_header,
+                separator=video_action_mapping_separator,
+            )
+            self.video_to_action = video_to_action
+        if video_boundary_dir_path is not None:
+            video_boundaries = load_video_boundaries(
+                video_boundary_dir_path,
+                has_header=video_boundary_has_header,
+                separator=video_boundary_separator,
+            )
+            self.video_boundaries = video_boundaries
+        if backgrounds is not None:
+            self.backgrounds = backgrounds

--- a/vut/base.py
+++ b/vut/base.py
@@ -9,17 +9,17 @@ from vut.util import Env
 
 class Base:
     env = Env()
-    text_to_index: dict[str, int] = {}
-    index_to_text: dict[int, str] = {}
-    action_to_steps: dict[str, list[str]] = {}
-    video_to_action: dict[str, str] = {}
-    video_boundaries: dict[str, list[tuple[int, int]]] = {}
-    backgrounds: list[str] = []
+    text_to_index: dict[str, int]
+    index_to_text: dict[int, str]
+    action_to_steps: dict[str, list[str]]
+    video_to_action: dict[str, str]
+    video_boundaries: dict[str, list[tuple[int, int]]]
+    backgrounds: list[str]
 
     def __init__(
         self,
         class_mapping_path: str | None = None,
-        class_mapping_has_header: bool = None,
+        class_mapping_has_header: bool = False,
         class_mapping_separator: str | None = ",",
         action_mapping_path: str | None = None,
         action_mapping_has_header: bool = False,
@@ -41,6 +41,9 @@ class Base:
             )
             self.text_to_index = text_to_index
             self.index_to_text = index_to_text
+        else:
+            self.text_to_index = {}
+            self.index_to_text = {}
         if action_mapping_path is not None:
             action_to_steps = load_action_mapping(
                 action_mapping_path,
@@ -49,6 +52,8 @@ class Base:
                 step_separator=action_mapping_step_separator,
             )
             self.action_to_steps = action_to_steps
+        else:
+            self.action_to_steps = {}
         if video_action_mapping_path is not None:
             video_to_action = load_video_action_mapping(
                 video_action_mapping_path,
@@ -56,6 +61,8 @@ class Base:
                 separator=video_action_mapping_separator,
             )
             self.video_to_action = video_to_action
+        else:
+            self.video_to_action = {}
         if video_boundary_dir_path is not None:
             video_boundaries = load_video_boundaries(
                 video_boundary_dir_path,
@@ -63,5 +70,9 @@ class Base:
                 separator=video_boundary_separator,
             )
             self.video_boundaries = video_boundaries
+        else:
+            self.video_boundaries = {}
         if backgrounds is not None:
             self.backgrounds = backgrounds
+        else:
+            self.backgrounds = []

--- a/vut/base.py
+++ b/vut/base.py
@@ -18,21 +18,39 @@ class Base:
 
     def __init__(
         self,
-        class_mapping_path: str | None = None,
+        class_mapping_path: str = None,
         class_mapping_has_header: bool = False,
-        class_mapping_separator: str | None = ",",
-        action_mapping_path: str | None = None,
+        class_mapping_separator: str = ",",
+        action_mapping_path: str = None,
         action_mapping_has_header: bool = False,
         action_mapping_action_separator: str = ",",
         action_mapping_step_separator: str = " ",
-        video_action_mapping_path: str | None = None,
+        video_action_mapping_path: str = None,
         video_action_mapping_has_header: bool = False,
         video_action_mapping_separator: str = ",",
-        video_boundary_dir_path: str | None = None,
+        video_boundary_dir_path: str = None,
         video_boundary_has_header: bool = False,
         video_boundary_separator: str = ",",
-        backgrounds: list[str] | None = None,
+        backgrounds: list[str] = None,
     ):
+        """Initialize the Base class.
+
+        Args:
+            class_mapping_path (str, optional): Path to the class mapping file. Defaults to None.
+            class_mapping_has_header (bool, optional): Whether the class mapping file has a header. Defaults to False.
+            class_mapping_separator (str, optional): Separator used in the class mapping file. Defaults to ",".
+            action_mapping_path (str, optional): Path to the action mapping file. Defaults to None.
+            action_mapping_has_header (bool, optional): Whether the action mapping file has a header. Defaults to False.
+            action_mapping_action_separator (str, optional): Separator used for actions in the action mapping file. Defaults to ",".
+            action_mapping_step_separator (str, optional): Separator used for steps in the action mapping file. Defaults to " ".
+            video_action_mapping_path (str, optional): Path to the video action mapping file. Defaults to None.
+            video_action_mapping_has_header (bool, optional): Whether the video action mapping file has a header. Defaults to False.
+            video_action_mapping_separator (str, optional): Separator used in the video action mapping file. Defaults to ",".
+            video_boundary_dir_path (str, optional): Path to the video boundary directory. Defaults to None.
+            video_boundary_has_header (bool, optional): Whether the video boundary files have headers. Defaults to False.
+            video_boundary_separator (str, optional): Separator used in the video boundary files. Defaults to ",".
+            backgrounds (list[str], optional): List of background images. Defaults to None.
+        """
         if class_mapping_path is not None:
             text_to_index, index_to_text = load_class_mapping(
                 class_mapping_path,

--- a/vut/io.py
+++ b/vut/io.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Any
 
 import cv2
 import numpy as np
@@ -126,15 +127,15 @@ def save_image(image: NDArray, path: str | Path) -> None:
     cv2.imwrite(str(path), image)
 
 
-def load_list(path: str | Path, callback=None) -> list:
+def load_list(path: str | Path, callback=None) -> list[str] | list[Any]:
     """Load a list from a file.
 
     Args:
         path (str | Path): Path to load the list from.
-        callback (callable, optional): A function to apply to each item after loading. Defaults to None.
+        callback (callable, optional): A function to apply to each item (string) after loading. Defaults to None.
 
     Returns:
-        list: Loaded list.
+        list: A list of strings loaded from the file. If callback is provided, the list will contain the results of applying the callback to each item.
     """
     with open(path, "r") as f:
         loaded_list = [line.strip() for line in f.readlines() if line.strip()]

--- a/vut/mapping.py
+++ b/vut/mapping.py
@@ -64,7 +64,7 @@ def to_class_mapping(x: list[tuple[int, str]]) -> tuple[dict[int, str], dict[str
         x (list[tuple[int, str]]): A list of tuples, where each tuple contains a class index and its name.
 
     Returns:
-        tuple[dict[int, str], dict[str, int]]: A tuple containing two dictionaries:
+        tuple[dict[str, int], dict[int, str]]: A tuple containing two dictionaries:
             - text_to_index: Mapping from class names to class indices.
             - index_to_text: Mapping from class indices to class names.
     """
@@ -138,7 +138,7 @@ def load_action_mapping(
         step_separator (str): Separator for the step name. Defaults to " ".
 
     Returns:
-        dict[str, list[str]]: A dictionary mapping step names to action names.
+        dict[str, list[str]]: A dictionary mapping action names to lists of step names.
     """
     path = Path(path)
     if not path.exists():

--- a/vut/mapping.py
+++ b/vut/mapping.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import numpy as np
 import torch
 from numpy.typing import NDArray
 from torch import Tensor
+
+from vut.io import load_list
 
 
 def to_class_name(
@@ -51,3 +55,218 @@ def to_class_index(x: list[str], text_to_index: dict[str, int]) -> list[int]:
         return []
     assert not isinstance(x[0], list), "List must be 1D"
     return [text_to_index.get(i, -1) for i in x]
+
+
+def to_class_mapping(x: list[tuple[int, str]]) -> tuple[dict[int, str], dict[str, int]]:
+    """Convert a list of class indices and names to a mapping.
+
+    Args:
+        x (list[tuple[int, str]]): A list of tuples, where each tuple contains a class index and its name.
+
+    Returns:
+        tuple[dict[int, str], dict[str, int]]: A tuple containing two dictionaries:
+            - text_to_index: Mapping from class names to class indices.
+            - index_to_text: Mapping from class indices to class names.
+    """
+    index_to_text = {}
+    text_to_index = {}
+    for i, text in x:
+        index_to_text[i] = text
+        text_to_index[text] = i
+    return text_to_index, index_to_text
+
+
+def load_class_mapping(
+    path: str | Path, has_header: bool = False, separator: str = ","
+) -> tuple[dict[int, str], dict[str, int]]:
+    """Load class mapping from a csv-like file.
+    Format should be:
+    ```
+    <index><separator><class_name>
+    <index><separator><class_name>
+    ...
+    ```
+    where <index> is an integer and <class_name> is a string.
+
+    Args:
+        path (str | Path): Path to the class mapping file.
+        has_header (bool): Whether the file has a header line. Defaults to False.
+
+    Returns:
+        tuple[dict[int, str], dict[str, int]]: A tuple containing two dictionaries:
+            - text_to_index: Mapping from class names to class indices.
+            - index_to_text: Mapping from class indices to class names.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    lines = load_list(path)
+    if has_header:
+        lines = lines[1:]
+    lines = [line.split(separator) for line in lines]
+    assert len(lines[0]) == 2, (
+        f"Invalid format in file: {path}. Expected format: <index>{separator}<class_name>"
+    )
+    try:
+        lines = [(int(line[0]), line[1]) for line in lines]
+    except ValueError:
+        raise ValueError(
+            f"Invalid index format in file: {path}. index must be an integer."
+        )
+    return to_class_mapping(lines)
+
+
+def load_action_mapping(
+    path: str | Path,
+    has_header: bool = False,
+    action_separator: str = ",",
+    step_separator: str = " ",
+) -> dict[str, list[str]]:
+    """Load action mapping from a csv-like file.
+    Format should be:
+    ```
+    <action_index><action_separator><step_name><step_separator><step_name>...
+    <action_index><action_separator><step_name><step_separator><step_name>...
+    ...
+    ```
+    where <action_index> is an integer and <step_name> is a string.
+
+    Args:
+        path (str | Path): Path to the action mapping file.
+        has_header (bool): Whether the file has a header line. Defaults to False.
+        action_separator (str): Separator for the action name. Defaults to ",".
+        step_separator (str): Separator for the step name. Defaults to " ".
+
+    Returns:
+        dict[str, list[str]]: A dictionary mapping step names to action names.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    lines = load_list(path)
+    if has_header:
+        lines = lines[1:]
+    lines = [line.split(action_separator) for line in lines]
+    assert len(lines[0]) == 2, (
+        f"Invalid format in file: {path}. Expected format: <index>{action_separator}<action_name>"
+    )
+    try:
+        lines = [(int(line[0]), line[1]) for line in lines]
+    except ValueError:
+        raise ValueError(f"Invalid format in file: {path}. index must be an integer.")
+    mapping = {}
+    for line in lines:
+        index, action = line
+        steps = action.split(step_separator)
+        mapping[index] = steps
+    return mapping
+
+
+def load_video_action_mapping(
+    path: str | Path,
+    has_header: bool = False,
+    separator: str = ",",
+) -> dict[str, str]:
+    """Load video action mapping from a csv-like file.
+    Format should be:
+    ```
+    <video_name><separator><action_name>
+    <video_name><separator><action_name>
+    ...
+    ```
+    where <video_name> and <action_name> are strings.
+
+    Args:
+        path (str | Path): Path to the video action mapping file.
+        has_header (bool): Whether the file has a header line. Defaults to False.
+        separator (str): Separator for the video name and action name. Defaults to ",".
+
+    Returns:
+        dict[str, str]: A dictionary mapping video names to action names.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    lines = load_list(path)
+    if has_header:
+        lines = lines[1:]
+    lines = [line.split(separator) for line in lines]
+    return dict(lines)
+
+
+def load_video_boundaries_from_file(
+    file_path: str | Path,
+    has_header: bool = False,
+    separator: str = ",",
+) -> list[tuple[int, int]]:
+    """Load boundaries of untrimmed video from a csv-like file.
+    Format should be:
+    ```
+    <start_frame><separator><end_frame>
+    <start_frame><separator><end_frame>
+    ...
+    ```
+    where <start_frame> and <end_frame> are integers.
+
+    Args:
+        file_path (str | Path): Path to the video boundaries file.
+        has_header (bool, optional): Whether the file has a header line. Defaults to False.
+        separator (str, optional): Separator for the video name and boundaries. Defaults to ",".
+
+    Returns:
+        list[tuple[int, int]]: A list of tuples containing the start and end frames from video.
+    """
+    file_path = Path(file_path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+    lines = load_list(file_path)
+    if has_header:
+        lines = lines[1:]
+    lines = [line.split(separator) for line in lines]
+    assert len(lines[0]) == 2, (
+        f"Invalid format in file: {file_path}. Expected format: <start_frame>{separator}<end_frame>"
+    )
+    try:
+        lines = [(int(line[0]), int(line[1])) for line in lines]
+    except ValueError:
+        raise ValueError(
+            f"Invalid format in file: {file_path}. start_frame and end_frame must be integers."
+        )
+    return lines
+
+
+def load_video_boundaries(
+    dir_path: str | Path,
+    has_header: bool = False,
+    separator: str = ",",
+) -> dict[str, list[tuple[int, int]]]:
+    """Load boundaries of untrimmed videos from multiple files in a directory.
+    Format should be:
+    ```
+    <start_frame><separator><end_frame>
+    <start_frame><separator><end_frame>
+    ...
+    ```
+    where <start_frame> and <end_frame> are integers.
+
+    Args:
+        dir_path (str | Path): Path to the directory containing video boundary files.
+        has_header (bool, optional): Whether the files have a header line. Defaults to False.
+        separator (str, optional): Separator for start and end frames. Defaults to ",".
+
+    Returns:
+        dict[str, list[tuple[int, int]]]: A dictionary mapping video names to their start and end frames.
+    """
+    dir_path = Path(dir_path)
+    if not dir_path.exists():
+        raise FileNotFoundError(f"Directory not found: {dir_path}")
+    if not dir_path.is_dir():
+        raise NotADirectoryError(f"Path is not a directory: {dir_path}")
+    files = [f for f in dir_path.iterdir() if f.is_file()]
+    mapping = {}
+    for file in files:
+        boundaries = load_video_boundaries_from_file(
+            file, has_header=has_header, separator=separator
+        )
+        mapping[file.stem] = boundaries
+    return mapping

--- a/vut/mapping.py
+++ b/vut/mapping.py
@@ -68,11 +68,11 @@ def to_class_mapping(x: list[tuple[int, str]]) -> tuple[dict[int, str], dict[str
             - text_to_index: Mapping from class names to class indices.
             - index_to_text: Mapping from class indices to class names.
     """
-    index_to_text = {}
     text_to_index = {}
+    index_to_text = {}
     for i, text in x:
-        index_to_text[i] = text
         text_to_index[text] = i
+        index_to_text[i] = text
     return text_to_index, index_to_text
 
 
@@ -125,11 +125,11 @@ def load_action_mapping(
     """Load action mapping from a csv-like file.
     Format should be:
     ```
-    <action_index><action_separator><step_name><step_separator><step_name>...
-    <action_index><action_separator><step_name><step_separator><step_name>...
+    <action_name><action_separator><step_name><step_separator><step_name>...
+    <action_name><action_separator><step_name><step_separator><step_name>...
     ...
     ```
-    where <action_index> is an integer and <step_name> is a string.
+    where <action_name> is a string and <step_name> is a string.
 
     Args:
         path (str | Path): Path to the action mapping file.
@@ -150,10 +150,6 @@ def load_action_mapping(
     assert len(lines[0]) == 2, (
         f"Invalid format in file: {path}. Expected format: <index>{action_separator}<action_name>"
     )
-    try:
-        lines = [(int(line[0]), line[1]) for line in lines]
-    except ValueError:
-        raise ValueError(f"Invalid format in file: {path}. index must be an integer.")
     mapping = {}
     for line in lines:
         index, action = line

--- a/vut/util.py
+++ b/vut/util.py
@@ -1,3 +1,4 @@
+import os
 import random
 
 import numpy as np
@@ -121,3 +122,55 @@ def to_tensor(x: list | NDArray | Tensor) -> Tensor:
     raise TypeError(
         f"Unsupported type: {type(x)}. Supported types are list, NDArray, and Tensor."
     )
+
+
+class Env:
+    def __call__(self, name: str) -> str:
+        """Get the value of an environment variable.
+
+        Args:
+            name (str): Name of the environment variable.
+
+        Returns:
+            str: Value of the environment variable or an empty string if not set.
+        """
+        return os.getenv(name, "")
+
+    def bool(self, name: str) -> bool:
+        """Get the boolean value of an environment variable.
+
+        Args:
+            name (str): Name of the environment variable.
+
+        Returns:
+            bool: True if the environment variable is set to '1', 'true', or 'yes', False otherwise.
+        """
+        return self(name).lower() in ("1", "true", "yes")
+
+    def int(self, name: str) -> int:
+        """Get the integer value of an environment variable.
+
+        Args:
+            name (str): Name of the environment variable.
+
+        Returns:
+            int: Integer value of the environment variable or 0 if not set.
+        """
+        try:
+            return int(self(name))
+        except ValueError:
+            return 0
+
+    def float(self, name: str) -> float:
+        """Get the float value of an environment variable.
+
+        Args:
+            name (str): Name of the environment variable.
+
+        Returns:
+            float: Float value of the environment variable or 0.0 if not set.
+        """
+        try:
+            return float(self(name))
+        except ValueError:
+            return 0.0

--- a/vut/visualize.py
+++ b/vut/visualize.py
@@ -20,6 +20,7 @@ def plot_palette(
     palette: NDArray | list[RGB] = None,
     n: int = 256,
     path: str | Path = "palette.png",
+    figsize: tuple[int, int] = (8, 2),
 ) -> None:
     """Plot a color palette.
 
@@ -28,6 +29,7 @@ def plot_palette(
         palette (NDArray | list[RGB], optional): A custom color palette. Defaults to None.
         n (int, optional): The number of colors in the colormap. Defaults to 256.
         path (str | Path, optional): The file path to save the plot. Defaults to "palette.png".
+        figsize (tuple[int, int], optional): The size of the figure. Defaults to (8, 2).
     """
     assert name is not None or palette is not None, (
         "Either name or palette must be provided"
@@ -38,7 +40,7 @@ def plot_palette(
         assert palette.ndim == 2, "Palette must be a 2D array"
         cmap = create_palette(palette)
     gradient = np.linspace(0, 1, n)
-    fig, ax = plt.subplots(figsize=(8, 2))
+    fig, ax = plt.subplots(figsize=figsize)
     ax.imshow(
         np.vstack((gradient, gradient)),
         aspect="auto",
@@ -57,6 +59,7 @@ def plot_image(
     show_axis: bool = False,
     is_jupyter: bool = False,
     return_canvas: bool = False,
+    figsize: tuple[int, int] = (8, 6),
 ) -> NDArray | None:
     """Plot a 3D array as an image.
 
@@ -67,13 +70,14 @@ def plot_image(
         show_axis (bool, optional): Whether to show the axis. Defaults to False.
         is_jupyter (bool, optional): Whether to display the plot in a Jupyter notebook. Defaults to False.
         return_canvas (bool, optional): Whether to return the canvas as a numpy array. Defaults to False.
+        figsize (tuple[int, int], optional): The size of the figure. Defaults to (8, 6).
 
     Returns:
         NDArray: The canvas as a numpy array if return_canvas is True, otherwise None.
     """
     assert data.ndim == 3, "Data must be a 3D array"
 
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=figsize)
     ax.imshow(data)
     if not show_axis:
         ax.axis("off")
@@ -177,6 +181,7 @@ def plot_feature(
     is_jupyter: bool = False,
     return_canvas: bool = False,
     palette: ColorMapName | list[RGB] | None = "plasma",
+    figsize: tuple[int, int] = (8, 6),
 ) -> NDArray | None:
     """Plot a 2D feature map.
 
@@ -187,13 +192,14 @@ def plot_feature(
         is_jupyter (bool, optional): Whether to display the plot in a Jupyter notebook. Defaults to False.
         return_canvas (bool, optional): Whether to return the canvas as a numpy array. Defaults to False.
         palette (ColorMapName | list[RGB], optional): The colormap to use. Defaults to "plasma".
+        figsize (tuple[int, int], optional): The size of the figure. Defaults to (8, 6).
 
     Returns:
         NDArray: The canvas as a numpy array if return_canvas is True, otherwise None.
     """
     assert data.ndim == 2, "Data must be a 2D array"
 
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=figsize)
     cax = ax.imshow(
         data, cmap=create_palette(palette) if isinstance(palette, list) else palette
     )
@@ -302,6 +308,7 @@ def plot_scatter(
     is_jupyter: bool = False,
     return_canvas: bool = False,
     palette: ColorMapName | list[RGB] | None = "plasma",
+    figsize: tuple[int, int] = (10, 8),
 ) -> NDArray | None:
     """Plot a 2D scatter plot of the data.
 
@@ -313,6 +320,7 @@ def plot_scatter(
         is_jupyter (bool, optional): Whether to display the plot in a Jupyter notebook. Defaults to False.
         return_canvas (bool, optional): Whether to return the canvas as a numpy array. Defaults to False.
         palette (ColorMapName | list[RGB] | None, optional): Colormap to use for the plot. Defaults to "plasma".
+        figsize (tuple[int, int], optional): Figure size (width, height). Defaults to (10, 8).
 
     Returns:
         NDArray | None: The canvas as a numpy array if return_canvas is True, otherwise None.
@@ -320,7 +328,7 @@ def plot_scatter(
     assert data.ndim == 2, "Data must be a 2D array"
     assert data.shape[1] == 2, "Data must be 2D embedding (n_samples, 2)"
 
-    fig, ax = plt.subplots(figsize=(10, 8))
+    fig, ax = plt.subplots(figsize=figsize)
     cmap = (
         create_palette(palette)
         if isinstance(palette, list)


### PR DESCRIPTION
This pull request introduces several changes across the codebase, including updates to dependencies, enhancements to testing, and improvements to functionality. Key updates include adding new dependencies, refining test cases, and introducing mock fixtures for testing video creation. Below is a categorized summary of the most important changes.

### Dependency Updates:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R19-R29): Added `einops`, `matplotlib`, and `torchvision` to the list of Python auto-import modules.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version to `0.1.6` and added `pre-commit>=4.2.0` to the development dependencies. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R55)

### Testing Enhancements:
* [`tests/test_base.py`](diffhunk://#diff-9d6c961a9df09671b4f476b17891ccefaca2c9893fdbdb7c570cb2c4ffd43382R1-R137): Added comprehensive test cases for the `Base` class, including fixtures for temporary files and directories to test mappings, boundaries, and environment variable access.
* [`tests/test_mapping.py`](diffhunk://#diff-5f1d47513ba8d7435babbde7a878b28fb0e412244363d13ae70a10152f5e293dR1-R17): Introduced new test cases for loading mappings (class, action, video action, and video boundaries) and added validation for missing files and directories. [[1]](diffhunk://#diff-5f1d47513ba8d7435babbde7a878b28fb0e412244363d13ae70a10152f5e293dR1-R17) [[2]](diffhunk://#diff-5f1d47513ba8d7435babbde7a878b28fb0e412244363d13ae70a10152f5e293dR158-R318)
* [`tests/test_visualize.py`](diffhunk://#diff-afcd5bce6fecb72ded4f78b8ddcfc7ceb9947afa1c0554413399b620a10a11bdR27-R51): Added a `mock_ffmpeg` fixture to mock `ffmpeg` functionality, ensuring tests for video creation (`make_video`) do not rely on external dependencies. [[1]](diffhunk://#diff-afcd5bce6fecb72ded4f78b8ddcfc7ceb9947afa1c0554413399b620a10a11bdR27-R51) [[2]](diffhunk://#diff-afcd5bce6fecb72ded4f78b8ddcfc7ceb9947afa1c0554413399b620a10a11bdL407-R432)

### Code Refinements:
* `tests/test_cuda.py`, `tests/test_logger.py`, `tests/test_util.py`: Replaced `MockFixture` with `MockerFixture` for better compatibility and clarity in mocking. [[1]](diffhunk://#diff-6deae64cdc8b70e42e1ad5f9605daac08ddd27153ddcba689b424cfc261f30caL6-R6) [[2]](diffhunk://#diff-c66f6ae944c1ee053e0433bfc6d6196bcc4bc3168db4f369eca10ca84615d00dL5-R5) [[3]](diffhunk://#diff-0dcbadaa6c70afb6fea041dec04bb89c3cc7fe201fb7c3185a669efa49769f28R1-R8)
* [`tests/test_visualize.py`](diffhunk://#diff-afcd5bce6fecb72ded4f78b8ddcfc7ceb9947afa1c0554413399b620a10a11bdL61-R86): Updated assertions for canvas dimensions in visualization tests to reflect updated output sizes. [[1]](diffhunk://#diff-afcd5bce6fecb72ded4f78b8ddcfc7ceb9947afa1c0554413399b620a10a11bdL61-R86) [[2]](diffhunk://#diff-afcd5bce6fecb72ded4f78b8ddcfc7ceb9947afa1c0554413399b620a10a11bdL109-R134)

### Licensing Update:
* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L5-L8): Removed specific licensing details for the `vut/models` directory, simplifying the license to apply uniformly across the project.