### PR TITLE
Release v0.1.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install the project
         run: uv sync --locked --all-extras --dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vut"
-version = "0.1.14"
+version = "0.1.15"
 description = "Toolkit for Video Understanding tasks"
 readme = "README.md"
 authors = [{ name = "kage1020", email = "contact@kage1020.com" }]
@@ -80,4 +80,4 @@ omit = ["*/__init__.py"]
 directory = "coverages"
 
 [tool.ruff]
-extend-ignore = ["F821"]
+lint.extend-ignore = ["F821"]

--- a/tests/models/test_i3d.py
+++ b/tests/models/test_i3d.py
@@ -64,6 +64,18 @@ def test_i3d__invalid_endpoint():
         I3D(final_endpoint="invalid_endpoint")
 
 
+def test_i3d__replace_logits_updates_num_classes():
+    model = I3D(num_classes=400)
+
+    assert model._num_classes == 400
+
+    model.replace_logits(num_classes=50)
+
+    assert model._num_classes == 50
+    assert model.logits.conv3d.out_channels == 50
+
+
+
 def test_unit3d():
     device = get_device()
     unit = Unit3D(in_channels=3, out_channels=64, kernel_shape=(3, 3, 3))

--- a/uv.lock
+++ b/uv.lock
@@ -2177,7 +2177,7 @@ wheels = [
 
 [[package]]
 name = "vut"
-version = "0.1.14"
+version = "0.1.15"
 source = { virtual = "." }
 
 [package.optional-dependencies]

--- a/vut/models/i3d.py
+++ b/vut/models/i3d.py
@@ -416,8 +416,8 @@ class I3D(nn.Module):
         self._num_classes = num_classes
         self.logits = Unit3D(
             in_channels=384 + 384 + 128 + 128,
-            output_channels=self._num_classes,
-            kernel_shape=[1, 1, 1],
+            out_channels=self._num_classes,
+            kernel_shape=(1, 1, 1),
             padding=0,
             activation_fn=None,
             use_batch_norm=False,

--- a/vut/models/i3d.py
+++ b/vut/models/i3d.py
@@ -10,6 +10,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from jaxtyping import Float32
 
+
 class MaxPool3dSamePadding(nn.MaxPool3d):
     stride: tuple[int, int, int]
     kernel_size: tuple[int, int, int]
@@ -410,6 +411,19 @@ class I3D(nn.Module):
 
         for k in self.end_points.keys():
             self.add_module(k, self.end_points[k])
+
+    def replace_logits(self, num_classes: int) -> None:
+        self._num_classes = num_classes
+        self.logits = Unit3D(
+            in_channels=384 + 384 + 128 + 128,
+            output_channels=self._num_classes,
+            kernel_shape=[1, 1, 1],
+            padding=0,
+            activation_fn=None,
+            use_batch_norm=False,
+            use_bias=True,
+            name="logits",
+        )
 
     def forward(
         self, x: Float32[Tensor, "batch channel frames height width"]


### PR DESCRIPTION
This pull request updates the `vut` package version and introduces a new method to the `I3D` model for easier modification of output classes. It also makes a configuration change for linting in `pyproject.toml`. The most important changes are grouped below:

**Model enhancements:**

* Added a new `replace_logits` method to the `I3D` model in `vut/models/i3d.py`, allowing the number of output classes to be easily changed by replacing the logits layer.

**Configuration updates:**

* Updated the package version from `0.1.14` to `0.1.15` in `pyproject.toml`.
* Changed the Ruff lint configuration in `pyproject.toml` to use `lint.extend-ignore` instead of `extend-ignore`, improving compatibility with the latest Ruff standards.

**Minor code cleanup:**

* Added a blank line for code style consistency in `vut/models/i3d.py`.